### PR TITLE
just-mr: change wording in info message

### DIFF
--- a/src/other_tools/just_mr/main.cpp
+++ b/src/other_tools/just_mr/main.cpp
@@ -1110,7 +1110,7 @@ void DefaultReachableRepositories(
     // report progress
     auto nr = repos_to_report->size();
     Logger::Log(LogLevel::Info,
-                "Found {} {} to check out",
+                "Found {} {} to set up",
                 nr,
                 nr == 1 ? "repository" : "repositories");
 


### PR DESCRIPTION
When asked to setup, report the number of repositories as repositories to "set up", not to "check out". Typically, we're not creating a checkout of that repository in the sense that some directory would contain the file strucutre of that repository in the file system. Typically, fetch into our big git repo, or create an artifical commit there to keep the resulting git tree there.