### PR TITLE
just-mr: remove unnecessary double quotes

### DIFF
--- a/src/other_tools/just_mr/main.cpp
+++ b/src/other_tools/just_mr/main.cpp
@@ -1323,9 +1323,8 @@ void DefaultReachableRepositories(
         cmd.emplace_back(*it);
     }
 
-    Logger::Log(LogLevel::Info,
-                "Setup finished, exec \"{}\"",
-                nlohmann::json(cmd).dump());
+    Logger::Log(
+        LogLevel::Info, "Setup finished, exec {}", nlohmann::json(cmd).dump());
 
     // create argv
     std::vector<char*> argv{};


### PR DESCRIPTION
... on reporting the exec command; json encoding is already quoting enough.