### PR TITLE
Fix typos "boostrap" -> "bootstrap".

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,7 +81,7 @@ of the empty object, if this variable is set. One configuration parameter
 is the build environment `ENV` that can be used to set an unusual
 value of `PATH`, e.g.,
 ``` sh
-env JUST_BUILD_CONF='{"ENV": {"PATH": "/opt/toolchain/bin"}}' python3 ./bin/boostrap.py
+env JUST_BUILD_CONF='{"ENV": {"PATH": "/opt/toolchain/bin"}}' python3 ./bin/bootstrap.py
 ```
 Additionally, if `SOURCE_DATE_EPOCH` is set in the build environment, it
 is forwarded to the build configuration as well. If, on the other hand,

--- a/doc/tutorial/just-execute.org
+++ b/doc/tutorial/just-execute.org
@@ -458,14 +458,14 @@ RUN apt install -y --no-install-recommends \
 RUN git clone https://github.com/just-buildsystem/justbuild.git
 # use a well defined commit to foster reproducibility
 RUN git checkout 246e1b7f28f319e4be5bd24466494e6b5868ca6f
-RUN cd justbuild && ./bin/bootstrap.py . /just-boostrapped
+RUN cd justbuild && ./bin/bootstrap.py . /just-bootstrapped
 
 # Stage 2: setup the required environment and run just execute
 #
 FROM debian:bullseye-slim
 
 # Copy the binary from the build container
-COPY --from=build /just-boostrapped/out/bin/just /bin/just
+COPY --from=build /just-bootstrapped/out/bin/just /bin/just
 
 # the environment created for this example happens to satisfy the
 # run-time dependencies of just remember to double check it with your


### PR DESCRIPTION
I know "boost rap" is a popular music genre among C++ programmers today, but nevertheless this is a typo.