### PR TITLE
just-import-git: also recognize the workspace root as a layer

### DIFF
--- a/bin/just-import-git.py
+++ b/bin/just-import-git.py
@@ -163,6 +163,8 @@ def extra_layers_to_import(repos_config, repos):
     as layers for the repositories to import."""
     extra_imports = set()
     for repo in repos:
+        if isinstance(repos_config[repo]["repository"], str):
+            extra_imports.add(repos_config[repo]["repository"])
         for layer in ["target_root", "rule_root", "expression_root"]:
             if layer in repos_config[repo]:
                 extra = repos_config[repo][layer]


### PR DESCRIPTION
In the definition of a repository, the workspace root (given by the key "repository") can contain either a description of that root (where to fetch it, whast to expect) or simply a reference to (the workspace root of) another repository. In the latter case, the referenced repository has to be imported as a layer, just as if had been specified as target_root, rule_root, or expression_root.