### PR TITLE
bootstrap: Improve OS/ARCH determination

### DIFF
--- a/bin/bootstrap.py
+++ b/bin/bootstrap.py
@@ -53,6 +53,8 @@ ARCHS = {
   'arm':'arm',
   'aarch64':'arm64'
 }
+if "OS" not in CONF:
+    CONF["OS"] = platform.system().lower()
 if "ARCH" not in CONF:
     MACH = platform.machine()
     if MACH in ARCHS:
@@ -80,6 +82,8 @@ ENV['PKG_CONFIG_PATH'] = ":".join(CONFIG_PATHS)
 
 CONF_STRING = json.dumps(CONF)
 
+OS=CONF["OS"]
+ARCH=CONF["ARCH"]
 AR="ar"
 CC="cc"
 CXX="c++"
@@ -202,8 +206,11 @@ def setup_deps(src_wrkdir):
             else:
                 os.symlink(os.path.normpath(include_dir),
                            os.path.join(include_location, include_name))
+            os_map = hints.get("os_map", dict())
+            arch_map = hints.get("arch_map", dict())
             if "build" in hints:
                 run(["sh", "-c", hints["build"].format(
+                    os=os_map.get(OS, OS), arch=arch_map.get(ARCH, ARCH),
                     cc=CC, cxx=CXX, ar=AR,
                     cflags=quote(CFLAGS), cxxflags=quote(CXXFLAGS),
                 )], cwd=subdir)

--- a/etc/repos.json
+++ b/etc/repos.json
@@ -233,7 +233,8 @@
     , "target_file_name": "TARGETS.boringssl"
     , "bindings": {"rules": "rules-boringssl"}
     , "bootstrap":
-      { "build": "SYS=`uname -s | tr 'A-Z' 'a-z'` && ARCH=`uname -m` && {cc} {cflags} -I . -I src/include -c *.c src/crypto/*.c  src/crypto/*/*.c $SYS-$ARCH/crypto/fipsmodule/*.S && {ar} cqs libcrypto.a *.o"
+      { "arch_map": {"arm64": "aarch64"}
+      , "build": "{cc} {cflags} -I . -I src/include -c *.c src/crypto/*.c  src/crypto/*/*.c {os}-{arch}/crypto/fipsmodule/*.S && {ar} cqs libcrypto.a *.o"
       , "link": ["-lcrypto", "-pthread"]
       , "include_dir": "src/include/openssl"
       , "include_name": "openssl"


### PR DESCRIPTION
... by making variables `os` and `arch` accessible to bootstrap hints. Furthermore, support the hints `os_map` and `arch_map` for mapping Justbuild's OS/ARCH to the terminology used by the repository. Values not covered by these maps will be passed through.