### PR TITLE
Add explicit fmt::formatter for nlohmann::basic_json

### DIFF
--- a/src/utils/cpp/TARGETS
+++ b/src/utils/cpp/TARGETS
@@ -16,7 +16,12 @@
   { "type": ["@", "rules", "CC", "library"]
   , "name": ["json"]
   , "hdrs": ["json.hpp"]
-  , "deps": ["gsl", ["@", "json", "", "json"], ["@", "gsl", "", "gsl"]]
+  , "deps":
+    [ "gsl"
+    , ["@", "json", "", "json"]
+    , ["@", "gsl", "", "gsl"]
+    , ["@", "fmt", "", "fmt"]
+    ]
   , "stage": ["src", "utils", "cpp"]
   }
 , "concepts":

--- a/src/utils/cpp/json.hpp
+++ b/src/utils/cpp/json.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "fmt/ostream.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/utils/cpp/gsl.hpp"
@@ -211,5 +212,11 @@ namespace detail {
     }
     return old_abbrev;
 }
+
+// Use nlohmann::basic_json::operator<<() for formatting via libfmt.
+// This explicit template specialization seems to be required starting with
+// libfmt 10.x.
+template <>
+struct fmt::formatter<nlohmann::basic_json<>> : ostream_formatter {};
 
 #endif  // INCLUDED_SRC_UTILS_CPP_JSON_HPP


### PR DESCRIPTION
The formatter is based on fmt's ostream_formatter, using the provided operator<<(std::ostream&) of nlohmann::basic_json. This is required to allow compilation against fmt 10.x.

This patch matches the patch file I added to the Arch Linux AUR build recipe ([link](https://aur.archlinux.org/cgit/aur.git/tree/nlohmann-basic_json-fmt.patch?h=justbuild)).

Fixes #40 