### PR TITLE
Fix export of remote API

### DIFF
--- a/etc/import/TARGETS.bazel_remote_apis
+++ b/etc/import/TARGETS.bazel_remote_apis
@@ -31,6 +31,7 @@
     , "The Remote Execution API is an API that, at its most general, allows clients"
     , "to request execution of binaries on a remote system."
     ]
-  , "flexible_config": ["ARCH", "ENV", "HOST_ARCH", "PATCH"]
+  , "flexible_config":
+    ["ARCH", "ENV", "HOST_ARCH", "PATCH", "TOOLCHAIN_CONFIG"]
   }
 }


### PR DESCRIPTION
As we patch that API, it also can implicitly depend on the toolchain (and hence its config), if we use a compiled implementation of patch. Making the TOOLCHAIN_CONFIG a flexible part of the config allow to, again, build static binaries as usual.