### PR TITLE
Allow MACH to be used as ARCH for valid ARCHs when bootstrapping

### DIFF
--- a/bin/bootstrap.py
+++ b/bin/bootstrap.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import hashlib
+from itertools import chain
 import json
 import os
 import shutil
@@ -21,6 +22,7 @@ import subprocess
 import sys
 import tempfile
 import platform
+import logging
 
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
@@ -66,6 +68,12 @@ if "ARCH" not in g_CONF:
     MACH = platform.machine()
     if MACH in ARCHS:
         g_CONF["ARCH"] = ARCHS[MACH]
+    elif MACH in ARCHS.values():
+        g_CONF["ARCH"] = MACH
+    else:
+        expected = ", ".join(chain(ARCHS.keys(), ARCHS.values()))
+        logging.error(f"Couldn't setup ARCH. Found {MACH} expected one of {expected}")
+
 if 'SOURCE_DATE_EPOCH' in os.environ:
     g_CONF['SOURCE_DATE_EPOCH'] = int(os.environ['SOURCE_DATE_EPOCH'])
 

--- a/bin/bootstrap.py
+++ b/bin/bootstrap.py
@@ -53,14 +53,14 @@ if 'JUST_BUILD_CONF' in os.environ:
 if "PACKAGE" in os.environ:
     g_CONF["ADD_CFLAGS"] = ["-Wno-error", "-Wno-pedantic"] + g_CONF.get(
         "ADD_CFLAGS", [])
-    g_CONF["ADD_CXXFLAGS"] = ["-Wno-error", "-Wno-pedantic"] + g_CONF.get(
+    g_CONF["ADD_CXXFLAGS"] = ["-std=c++20", "-Wno-error", "-Wno-pedantic"] + g_CONF.get(
         "ADD_CXXFLAGS", [])
 
 ARCHS: Dict[str, str] = {
     'i686': 'x86',
     'x86_64': 'x86_64',
     'arm': 'arm',
-    'aarch64': 'arm64'
+    'aarch64': 'arm64',
 }
 if "OS" not in g_CONF:
     g_CONF["OS"] = platform.system().lower()
@@ -176,7 +176,7 @@ def quote(args: List[str]) -> str:
 
 
 def run(cmd: List[str], *, cwd: str, **kwargs: Any) -> None:
-    print("Running %r in %r" % (cmd, cwd), flush=True)
+    print("Running %r in %r" % (" ".join(cmd), cwd), flush=True)
     subprocess.run(cmd, cwd=cwd, check=True, **kwargs)
 
 
@@ -237,7 +237,7 @@ def setup_deps(src_wrkdir: str) -> Json:
                         cxx=g_CXX,
                         ar=g_AR,
                         cflags=quote(g_CFLAGS),
-                        cxxflags=quote(g_CXXFLAGS),
+                        cxxflags=quote(["-std=c++20"] + g_CXXFLAGS),
                     )
                 ],
                     cwd=subdir)

--- a/etc/repos.json
+++ b/etc/repos.json
@@ -236,18 +236,18 @@
   , "ssl":
     { "repository":
       { "type": "archive"
-      , "content": "19cdde8ba529848172c09e84e3deb2c92dc670c3"
-      , "fetch": "https://github.com/google/boringssl/archive/6195bf8242156c9a2fa75702eee058f91b86a88b.tar.gz"
-      , "sha256": "ad0b806b6c5cbd6cae121c608945d5fed468748e330632e8d53315089ad52c67"
-      , "sha512": "bd0ff23103695a08c5072ef4e88042c32b684295ee6434124d9c9292586b72863c35246cd8002ad3de3a79a9dfe10a1e0beb594c1625bdf1d6f6175821ca75a1"
-      , "subdir": "boringssl-6195bf8242156c9a2fa75702eee058f91b86a88b"
+      , "content": "231510cf506711eae6f7f06be9626bc7e44982b4"
+      , "fetch": "https://codeload.github.com/google/boringssl/zip/231510cf506711eae6f7f06be9626bc7e44982b4"
+      , "sha256": "1bc5c01e4d027392b40d358478ebac33d1c1bd7154c3b808a8876883d76fa08b"
+      , "sha512": "f099499868ef04e43841b86952b6c945db66151dcf8af3e0dd3d8a71353789e7499b98f5b2fda83b2c6f6f7391df94d9fefb50e11e1e0aa86dc661704c0f636d"
+      , "subdir": "boringssl-231510cf506711eae6f7f06be9626bc7e44982b4"
       }
     , "target_root": "import targets"
     , "target_file_name": "TARGETS.boringssl"
     , "bindings": {"rules": "rules-boringssl"}
     , "bootstrap":
       { "arch_map": {"arm64": "aarch64"}
-      , "build": "{cc} {cflags} -I . -I src/include -c *.c src/crypto/*.c  src/crypto/*/*.c {os}-{arch}/crypto/fipsmodule/*.S && {ar} cqs libcrypto.a *.o"
+      , "build": "{cc} {cflags} -I include -c ssl/*.c crypto/*.c crypto/*/*.c && {ar} cqs libcrypto.a *.o"
       , "link": ["-lcrypto", "-pthread"]
       , "include_dir": "src/include/openssl"
       , "include_name": "openssl"


### PR DESCRIPTION
In some cases (e.g. MacOS, arm CPUs) `platform.machine()` does not provide a valid arch (in terms of the acceptable keys), but the result is technically a valid arch.

This commit allows using the result of `platform.machine()` directly if it is a valid arch, or displays an error message. This commit does not increase the number of valid archs, but it allows for more lenient resolution.

PS, I am aware that MacOS is not supported yet.