### PR TITLE
["CC/pkgconfig", "system_library"]: honor ENV also for aux action

### DIFF
--- a/rules/CC/pkgconfig/EXPRESSIONS
+++ b/rules/CC/pkgconfig/EXPRESSIONS
@@ -162,6 +162,7 @@
                   ]
                 }
               ]
+            , "env": {"type": "var", "name": "ENV"}
             , "outs": [{"type": "var", "name": "ldflags-filename"}]
             }
           }


### PR DESCRIPTION
Our pkg config rule postprocesses the output of pkgconfig to add options -rpath where appropriate. This postprocessing, however, relies on (standard) tools from the environment, in particular cat(1). Therefore, the environment (in particular PATH) needs to be set properly for this auxilliary action.