### PR TITLE
drop #ifdef __unix__ preprocessor guards

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,13 @@
 # Installing the `just` binary
 
+Building `just` requires a sufficiently UNIX-like operating system; in
+particular, the header files `<fnctl.h>`, `<fnmatch.h>`, `<pwd.h>`,
+`<sys/file.h>`, `<sys/stat.h>`, `<sys/types.h>`, `<sys/wait.h>`,
+and `<unistd.h>` are used. There is also the assumption that for
+symlinks (if used) it does not make a difference if they point to
+a file, directory, or are dangling. The tool was successfully built
+and tested on a number of Linux distributions.
+
 ## Building `just` using an older version of `just-mr` and `just`
 
 If an older installation of `just` is already available, `just`

--- a/src/buildtool/build_engine/target_map/target_map.cpp
+++ b/src/buildtool/build_engine/target_map/target_map.cpp
@@ -14,12 +14,6 @@
 
 #include "src/buildtool/build_engine/target_map/target_map.hpp"
 
-#ifdef __unix__
-#include <fnmatch.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <algorithm>
 #include <compare>
 #include <cstdint>
@@ -36,6 +30,8 @@
 #include <utility>
 #include <variant>
 #include <vector>
+
+#include <fnmatch.h>
 
 #include "fmt/core.h"
 #include "src/buildtool/build_engine/analysed_target/target_graph_information.hpp"

--- a/src/buildtool/execution_api/common/common_api.cpp
+++ b/src/buildtool/execution_api/common/common_api.cpp
@@ -14,18 +14,14 @@
 
 #include "src/buildtool/execution_api/common/common_api.hpp"
 
-#ifdef __unix__
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <cstddef>
 #include <exception>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <utility>
+
+#include <unistd.h>
 
 #include "fmt/core.h"
 #include "src/buildtool/execution_api/common/message_limits.hpp"

--- a/src/buildtool/execution_api/common/ids.hpp
+++ b/src/buildtool/execution_api/common/ids.hpp
@@ -15,13 +15,6 @@
 #ifndef INCLUDED_SRC_BUILDTOOL_EXECUTION_API_COMMON_IDS_HPP
 #define INCLUDED_SRC_BUILDTOOL_EXECUTION_API_COMMON_IDS_HPP
 
-#ifdef __unix__
-#include <sys/types.h>
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -32,6 +25,9 @@
 #include <sstream>
 #include <string>
 #include <thread>
+
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "fmt/core.h"
 #include "gsl/gsl"

--- a/src/buildtool/execution_api/execution_service/server_implementation.cpp
+++ b/src/buildtool/execution_api/execution_service/server_implementation.cpp
@@ -14,18 +14,13 @@
 
 #include "src/buildtool/execution_api/execution_service/server_implementation.hpp"
 
-#ifdef __unix__
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <memory>
 #include <utility>
 #include <variant>
 #include <vector>
 
 #include <grpcpp/grpcpp.h>
+#include <unistd.h>
 
 #include "fmt/core.h"
 #include "nlohmann/json.hpp"

--- a/src/buildtool/file_system/atomic.cpp
+++ b/src/buildtool/file_system/atomic.cpp
@@ -14,16 +14,12 @@
 
 #include "src/buildtool/file_system/atomic.hpp"
 
-#ifdef __unix__
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+
+#include <unistd.h>
 
 #include "fmt/core.h"
 

--- a/src/buildtool/graph_traverser/graph_traverser.cpp
+++ b/src/buildtool/graph_traverser/graph_traverser.cpp
@@ -15,11 +15,6 @@
 #include "src/buildtool/graph_traverser/graph_traverser.hpp"
 
 #ifndef BOOTSTRAP_BUILD_TOOL
-#ifdef __unix__
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
 
 #include <algorithm>
 #include <atomic>
@@ -34,6 +29,8 @@
 #include <sstream>
 #include <thread>
 #include <unordered_set>
+
+#include <unistd.h>
 
 #include "fmt/core.h"
 #include "src/buildtool/common/artifact_blob.hpp"

--- a/src/buildtool/main/archive.cpp
+++ b/src/buildtool/main/archive.cpp
@@ -16,12 +16,6 @@
 
 #include "src/buildtool/main/archive.hpp"
 
-#ifdef __unix__
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <functional>
 #include <map>
 #include <memory>
@@ -29,6 +23,8 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+#include <unistd.h>
 
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"

--- a/src/buildtool/main/install_cas.cpp
+++ b/src/buildtool/main/install_cas.cpp
@@ -14,12 +14,6 @@
 
 #include "src/buildtool/main/install_cas.hpp"
 
-#ifdef __unix__
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
@@ -28,6 +22,8 @@
 #include <sstream>
 #include <utility>
 #include <vector>
+
+#include <unistd.h>
 
 #include "gsl/gsl"
 #include "src/buildtool/common/artifact_digest.hpp"

--- a/src/buildtool/serve_api/serve_service/serve_server_implementation.cpp
+++ b/src/buildtool/serve_api/serve_service/serve_server_implementation.cpp
@@ -16,12 +16,6 @@
 
 #include "src/buildtool/serve_api/serve_service/serve_server_implementation.hpp"
 
-#ifdef __unix__
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <filesystem>
 #include <memory>
 #include <utility>
@@ -29,6 +23,7 @@
 #include <vector>
 
 #include <grpcpp/grpcpp.h>
+#include <unistd.h>
 
 #include "fmt/core.h"
 #include "nlohmann/json.hpp"

--- a/src/buildtool/system/system.cpp
+++ b/src/buildtool/system/system.cpp
@@ -15,13 +15,10 @@
 #include "src/buildtool/system/system.hpp"
 
 #ifdef VALGRIND_BUILD
-#ifdef __unix__
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif  // __unix__
 #include <array>
 #include <string>
+
+#include <unistd.h>
 #else
 #include <cstdlib>
 #endif  // VALGRIND_BUILD

--- a/src/buildtool/system/system_command.hpp
+++ b/src/buildtool/system/system_command.hpp
@@ -15,14 +15,6 @@
 #ifndef INCLUDED_SRC_BUILDTOOL_SYSTEM_SYSTEM_COMMAND_HPP
 #define INCLUDED_SRC_BUILDTOOL_SYSTEM_SYSTEM_COMMAND_HPP
 
-#ifdef __unix__
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <algorithm>  // for transform
 #include <cerrno>     // for errno
 #include <cstdio>
@@ -36,6 +28,10 @@
 #include <string>
 #include <utility>  // std::move
 #include <vector>
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "gsl/gsl"
 #include "src/buildtool/file_system/file_system_manager.hpp"

--- a/src/other_tools/just_mr/launch.cpp
+++ b/src/other_tools/just_mr/launch.cpp
@@ -14,12 +14,6 @@
 
 #include "src/other_tools/just_mr/launch.hpp"
 
-#ifdef __unix__
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <algorithm>
 #include <cerrno>  // for errno
 #include <cstdlib>
@@ -35,6 +29,8 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+#include <unistd.h>
 
 #include "fmt/chrono.h"
 #include "fmt/core.h"

--- a/src/utils/cpp/file_locking.cpp
+++ b/src/utils/cpp/file_locking.cpp
@@ -14,16 +14,12 @@
 
 #include "src/utils/cpp/file_locking.hpp"
 
-#ifdef __unix__
-#include <sys/file.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <cerrno>   // for errno
 #include <cstring>  // for strerror()
 #include <exception>
 #include <mutex>
+
+#include <sys/file.h>
 
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/buildtool/logging/log_level.hpp"

--- a/src/utils/cpp/tmp_dir.cpp
+++ b/src/utils/cpp/tmp_dir.cpp
@@ -14,15 +14,11 @@
 
 #include "src/utils/cpp/tmp_dir.hpp"
 
-#ifdef __unix__
-#include <unistd.h>
-#else
-#error "Non-unix is not supported yet"
-#endif
-
 #include <cstdlib>
 #include <string_view>
 #include <tuple>
+
+#include <unistd.h>
 
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/buildtool/logging/log_level.hpp"


### PR DESCRIPTION
... as those do not increase portability; in fact, there are quite a few UNIX-like systems that do not set this preprocessor macro. Instead, document that we only support sufficiently UNIX-like systems in the documentation and also documet where we succesfully built and tested the tool (giving an implicit hint where we did not try). In the code, however, just try to include the relevant files.