### PR TITLE
Improve debug-logging on caching

### DIFF
--- a/src/buildtool/execution_engine/executor/executor.hpp
+++ b/src/buildtool/execution_engine/executor/executor.hpp
@@ -811,7 +811,11 @@ class ExecutorImpl {
             }
             message += nlohmann::json(action->Command()).dump() +
                        " in environment " +
-                       nlohmann::json(action->Env()).dump() + "\n";
+                       nlohmann::json(action->Env()).dump();
+            if (response->IsCached()) {
+                message += " (cached)";
+            }
+            message += "\n";
             if (response->HasStdOut()) {
                 if (has_both) {
                     message += "Stdout:\n";

--- a/src/buildtool/storage/local_ac.tpp
+++ b/src/buildtool/storage/local_ac.tpp
@@ -40,7 +40,7 @@ auto LocalAC<kDoGlobalUplink>::CachedResult(ArtifactDigest const& action_id)
     const noexcept -> std::optional<bazel_re::ActionResult> {
     auto const cas_key = ReadActionKey(action_id);
     if (not cas_key) {
-        logger_->Emit(LogLevel::Debug, cas_key.error());
+        logger_->Emit(LogLevel::Trace, cas_key.error());
         return std::nullopt;
     }
     auto result = ReadAction(*cas_key);


### PR DESCRIPTION
When logging at debug level every action gets shown with command line and environment. Moreover, from local action-cache debug logging we can also see cache misses. However, those are hard to correlate. Therefore, include in the debug message for an action the information whether it was cached and demote the action-cache-miss message.