### PR TITLE
Update fmt dependency to 12.2.0

### DIFF
--- a/etc/repos.in.json
+++ b/etc/repos.in.json
@@ -225,11 +225,11 @@
   , "fmt":
     { "repository":
       { "type": "zip"
-      , "content": "da6ad435963d4578c63c723e61a1e6b136fd61d8"
-      , "fetch": "https://github.com/fmtlib/fmt/releases/download/11.2.0/fmt-11.2.0.zip"
-      , "sha256": "203eb4e8aa0d746c62d8f903df58e0419e3751591bb53ff971096eaa0ebd4ec3"
-      , "sha512": "75586d02284a33c0c101b6e78cbb1d61f169610ae9027ddfc20936751a8c2ac4453f3046e7b05fa167a8f8eedeafde0f4cb0bff4f798c17c80994521f660174d"
-      , "subdir": "fmt-11.2.0"
+      , "content": "4e761e8f52da03e28b32e761dc5231c7d080508d"
+      , "fetch": "https://github.com/fmtlib/fmt/releases/download/12.2.0/fmt-12.2.0.zip"
+      , "sha256": "a2f4a8d51178f954e4c339007f77edd76ba0cb2e36f87a48e5a5403d9be5878f"
+      , "sha512": "5d184f0fccd0630ef774b70e795496a3320e56ee32ca682787d11db7dbb3173d70f3375fd8a61776ba167d880b888adea03fa3c977241467a5e863874672f5a0"
+      , "subdir": "fmt-12.2.0"
       }
     , "target_root": "import targets"
     , "target_file_name": "TARGETS.fmt"

--- a/etc/repos.json
+++ b/etc/repos.json
@@ -310,11 +310,11 @@
     "fmt": {
       "repository": {
         "type": "zip",
-        "content": "da6ad435963d4578c63c723e61a1e6b136fd61d8",
-        "fetch": "https://github.com/fmtlib/fmt/releases/download/11.2.0/fmt-11.2.0.zip",
-        "sha256": "203eb4e8aa0d746c62d8f903df58e0419e3751591bb53ff971096eaa0ebd4ec3",
-        "sha512": "75586d02284a33c0c101b6e78cbb1d61f169610ae9027ddfc20936751a8c2ac4453f3046e7b05fa167a8f8eedeafde0f4cb0bff4f798c17c80994521f660174d",
-        "subdir": "fmt-11.2.0"
+        "content": "4e761e8f52da03e28b32e761dc5231c7d080508d",
+        "fetch": "https://github.com/fmtlib/fmt/releases/download/12.2.0/fmt-12.2.0.zip",
+        "sha256": "a2f4a8d51178f954e4c339007f77edd76ba0cb2e36f87a48e5a5403d9be5878f",
+        "sha512": "5d184f0fccd0630ef774b70e795496a3320e56ee32ca682787d11db7dbb3173d70f3375fd8a61776ba167d880b888adea03fa3c977241467a5e863874672f5a0",
+        "subdir": "fmt-12.2.0"
       },
       "target_root": "import targets",
       "target_file_name": "TARGETS.fmt",

--- a/lint/iwyu-mapping.imp
+++ b/lint/iwyu-mapping.imp
@@ -100,11 +100,6 @@
     # "git2/XXX.h" => <git2.h> where XXX doesn't contain '/'
     { "include": ["@\"git2/[^/]+\\.h\"", "private", "<git2.h>", "public"] },
 
-    # "fmt/core.h" is for compatibility reasons; otherwise, include the suggested
-    # headers if they don't break the pkg build
-    { "include": ["\"fmt/format.h\"", "private", "\"fmt/core.h\"", "public"] },
-    { "include": ["\"fmt/base.h\"", "private", "\"fmt/core.h\"", "public"] },
-
     { "include": ["@\"catch2/matchers/.*\"", "private", "\"catch2/matchers/catch_matchers_all.hpp\"", "public"] },
     { "include": ["@\"catch2/generators/.*\"", "private", "\"catch2/generators/catch_generators_all.hpp\"", "public"] },
 

--- a/src/buildtool/auth/authentication.hpp
+++ b/src/buildtool/auth/authentication.hpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <variant>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/logger.hpp"
 #include "src/utils/cpp/expected.hpp"

--- a/src/buildtool/build_engine/base_maps/directory_map.cpp
+++ b/src/buildtool/build_engine/base_maps/directory_map.cpp
@@ -17,7 +17,7 @@
 #include <functional>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/multithreading/async_map_consumer.hpp"
 
 auto BuildMaps::Base::CreateDirectoryEntriesMap(

--- a/src/buildtool/build_engine/base_maps/entity_name.hpp
+++ b/src/buildtool/build_engine/base_maps/entity_name.hpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name_data.hpp"

--- a/src/buildtool/build_engine/base_maps/expression_function.hpp
+++ b/src/buildtool/build_engine/base_maps/expression_function.hpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/expression/configuration.hpp"

--- a/src/buildtool/build_engine/base_maps/expression_map.cpp
+++ b/src/buildtool/build_engine/base_maps/expression_map.cpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/build_engine/base_maps/field_reader.hpp"
 
 namespace BuildMaps::Base {

--- a/src/buildtool/build_engine/base_maps/field_reader.hpp
+++ b/src/buildtool/build_engine/base_maps/field_reader.hpp
@@ -26,7 +26,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name.hpp"

--- a/src/buildtool/build_engine/base_maps/json_file_map.hpp
+++ b/src/buildtool/build_engine/base_maps/json_file_map.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <utility>  // std::move
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/base_maps/module_name.hpp"

--- a/src/buildtool/build_engine/base_maps/rule_map.cpp
+++ b/src/buildtool/build_engine/base_maps/rule_map.cpp
@@ -22,7 +22,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/build_engine/base_maps/entity_name.hpp"
 #include "src/buildtool/build_engine/base_maps/expression_function.hpp"
 #include "src/buildtool/build_engine/base_maps/field_reader.hpp"

--- a/src/buildtool/build_engine/base_maps/source_map.cpp
+++ b/src/buildtool/build_engine/base_maps/source_map.cpp
@@ -23,7 +23,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/analysed_target/target_graph_information.hpp"
 #include "src/buildtool/build_engine/base_maps/module_name.hpp"

--- a/src/buildtool/build_engine/base_maps/user_rule.hpp
+++ b/src/buildtool/build_engine/base_maps/user_rule.hpp
@@ -29,7 +29,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/buildtool/build_engine/base_maps/entity_name_data.hpp"
 #include "src/buildtool/build_engine/base_maps/expression_function.hpp"

--- a/src/buildtool/build_engine/expression/evaluator.cpp
+++ b/src/buildtool/build_engine/expression/evaluator.cpp
@@ -29,7 +29,7 @@
 #include <unordered_set>
 #include <utility>  // std::move
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/expression/configuration.hpp"
 #include "src/buildtool/build_engine/expression/expression.hpp"

--- a/src/buildtool/build_engine/expression/expression.cpp
+++ b/src/buildtool/build_engine/expression/expression.cpp
@@ -19,7 +19,7 @@
 #include <optional>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/crypto/hash_function.hpp"
 #include "src/buildtool/crypto/hasher.hpp"
 #include "src/utils/cpp/gsl.hpp"

--- a/src/buildtool/build_engine/expression/expression.hpp
+++ b/src/buildtool/build_engine/expression/expression.hpp
@@ -28,7 +28,7 @@
 #include <variant>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name_data.hpp"
 #include "src/buildtool/build_engine/expression/expression_ptr.hpp"

--- a/src/buildtool/build_engine/expression/linked_map.hpp
+++ b/src/buildtool/build_engine/expression/linked_map.hpp
@@ -26,7 +26,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/multithreading/atomic_value.hpp"
 #include "src/utils/cpp/hash_combine.hpp"
 

--- a/src/buildtool/build_engine/target_map/absent_target_map.cpp
+++ b/src/buildtool/build_engine/target_map/absent_target_map.cpp
@@ -22,7 +22,7 @@
 #include <utility>  // std::move
 #include <variant>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/build_engine/analysed_target/target_graph_information.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name_data.hpp"
 #include "src/buildtool/build_engine/expression/configuration.hpp"

--- a/src/buildtool/build_engine/target_map/built_in_rules.cpp
+++ b/src/buildtool/build_engine/target_map/built_in_rules.cpp
@@ -32,7 +32,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/build_engine/analysed_target/analysed_target.hpp"
 #include "src/buildtool/build_engine/analysed_target/target_graph_information.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name.hpp"

--- a/src/buildtool/build_engine/target_map/configured_target.hpp
+++ b/src/buildtool/build_engine/target_map/configured_target.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/build_engine/base_maps/entity_name_data.hpp"
 #include "src/buildtool/build_engine/expression/configuration.hpp"
 #include "src/utils/cpp/hash_combine.hpp"

--- a/src/buildtool/build_engine/target_map/export.cpp
+++ b/src/buildtool/build_engine/target_map/export.cpp
@@ -25,7 +25,7 @@
 #include <variant>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/analysed_target/analysed_target.hpp"
 #include "src/buildtool/build_engine/analysed_target/target_graph_information.hpp"

--- a/src/buildtool/build_engine/target_map/target_map.cpp
+++ b/src/buildtool/build_engine/target_map/target_map.cpp
@@ -37,7 +37,7 @@
 #include <variant>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/build_engine/analysed_target/target_graph_information.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name_data.hpp"

--- a/src/buildtool/build_engine/target_map/utils.cpp
+++ b/src/buildtool/build_engine/target_map/utils.cpp
@@ -24,7 +24,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/build_engine/base_maps/entity_name.hpp"
 #include "src/buildtool/build_engine/expression/evaluator.hpp"
 #include "src/buildtool/build_engine/expression/expression.hpp"

--- a/src/buildtool/common/artifact.hpp
+++ b/src/buildtool/common/artifact.hpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"

--- a/src/buildtool/common/artifact_blob.cpp
+++ b/src/buildtool/common/artifact_blob.cpp
@@ -16,7 +16,7 @@
 
 #include <exception>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/utils/cpp/hash_combine.hpp"

--- a/src/buildtool/common/cli.hpp
+++ b/src/buildtool/common/cli.hpp
@@ -30,7 +30,7 @@
 #include <vector>
 
 #include "CLI/CLI.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/expression/evaluator.hpp"

--- a/src/buildtool/common/location.cpp
+++ b/src/buildtool/common/location.cpp
@@ -14,7 +14,7 @@
 
 #include "src/buildtool/common/location.hpp"
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/logger.hpp"

--- a/src/buildtool/common/remote/client_common.hpp
+++ b/src/buildtool/common/remote/client_common.hpp
@@ -25,7 +25,7 @@
 
 #include <grpcpp/grpcpp.h>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/rpc/status.pb.h"
 #include "gsl/gsl"
 #include "src/buildtool/auth/authentication.hpp"

--- a/src/buildtool/common/remote/remote_common.hpp
+++ b/src/buildtool/common/remote/remote_common.hpp
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/remote/port.hpp"
 #include "src/utils/cpp/expected.hpp"

--- a/src/buildtool/common/remote/retry.cpp
+++ b/src/buildtool/common/remote/retry.cpp
@@ -19,7 +19,7 @@
 #include <chrono>
 #include <thread>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 
 auto WithRetry(CallableReturningRetryResponse const& f,

--- a/src/buildtool/common/remote/retry_config.hpp
+++ b/src/buildtool/common/remote/retry_config.hpp
@@ -20,7 +20,7 @@
 #include <random>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/utils/cpp/expected.hpp"
 

--- a/src/buildtool/common/tree.hpp
+++ b/src/buildtool/common/tree.hpp
@@ -22,7 +22,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/action.hpp"
 #include "src/buildtool/common/action_description.hpp"

--- a/src/buildtool/common/tree_overlay.hpp
+++ b/src/buildtool/common/tree_overlay.hpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/action.hpp"
 #include "src/buildtool/common/action_description.hpp"

--- a/src/buildtool/computed_roots/artifacts_root.cpp
+++ b/src/buildtool/computed_roots/artifacts_root.cpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/expression/expression.hpp"

--- a/src/buildtool/computed_roots/evaluate.cpp
+++ b/src/buildtool/computed_roots/evaluate.cpp
@@ -32,7 +32,7 @@
 #include <variant>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name_data.hpp"
 #include "src/buildtool/build_engine/expression/configuration.hpp"

--- a/src/buildtool/computed_roots/lookup_cache.cpp
+++ b/src/buildtool/computed_roots/lookup_cache.cpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name_data.hpp"
 #include "src/buildtool/build_engine/base_maps/field_reader.hpp"

--- a/src/buildtool/computed_roots/roots_progress.cpp
+++ b/src/buildtool/computed_roots/roots_progress.cpp
@@ -17,7 +17,7 @@
 #include <functional>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/logging/log_level.hpp"
 
 auto RootsProgress::Reporter(gsl::not_null<Statistics*> const& stats,

--- a/src/buildtool/crypto/hash_info.cpp
+++ b/src/buildtool/crypto/hash_info.cpp
@@ -14,7 +14,7 @@
 
 #include "src/buildtool/crypto/hash_info.hpp"
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/protocol_traits.hpp"
 #include "src/buildtool/crypto/hasher.hpp"
 #include "src/utils/cpp/hex_string.hpp"

--- a/src/buildtool/execution_api/bazel_msg/bazel_msg_factory.cpp
+++ b/src/buildtool/execution_api/bazel_msg/bazel_msg_factory.cpp
@@ -27,7 +27,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/duration.pb.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "src/buildtool/common/artifact_digest_factory.hpp"

--- a/src/buildtool/execution_api/common/bytestream_utils.cpp
+++ b/src/buildtool/execution_api/common/bytestream_utils.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/common/bazel_types.hpp"
 

--- a/src/buildtool/execution_api/common/common_api.cpp
+++ b/src/buildtool/execution_api/common/common_api.cpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/execution_api/common/message_limits.hpp"
 #include "src/buildtool/file_system/object_type.hpp"
 #include "src/buildtool/logging/log_level.hpp"

--- a/src/buildtool/execution_api/common/ids.hpp
+++ b/src/buildtool/execution_api/common/ids.hpp
@@ -33,7 +33,7 @@
 #include <string>
 #include <thread>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/buildtool/crypto/hash_function.hpp"
 #include "src/buildtool/logging/log_level.hpp"

--- a/src/buildtool/execution_api/execution_service/ac_server.cpp
+++ b/src/buildtool/execution_api/execution_service/ac_server.cpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"

--- a/src/buildtool/execution_api/execution_service/bytestream_server.cpp
+++ b/src/buildtool/execution_api/execution_service/bytestream_server.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <string_view>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/stubs/port.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"

--- a/src/buildtool/execution_api/execution_service/cas_server.cpp
+++ b/src/buildtool/execution_api/execution_service/cas_server.cpp
@@ -24,7 +24,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "google/rpc/status.pb.h"
 #include "nlohmann/json.hpp"

--- a/src/buildtool/execution_api/execution_service/cas_utils.cpp
+++ b/src/buildtool/execution_api/execution_service/cas_utils.cpp
@@ -17,7 +17,7 @@
 #include <optional>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/buildtool/common/protocol_traits.hpp"
 #include "src/buildtool/crypto/hash_function.hpp"

--- a/src/buildtool/execution_api/execution_service/execution_server.cpp
+++ b/src/buildtool/execution_api/execution_service/execution_server.cpp
@@ -27,7 +27,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/any.pb.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "google/protobuf/timestamp.pb.h"

--- a/src/buildtool/execution_api/execution_service/operations_server.cpp
+++ b/src/buildtool/execution_api/execution_service/operations_server.cpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/execution_api/execution_service/operation_cache.hpp"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/utils/cpp/hex_string.hpp"

--- a/src/buildtool/execution_api/execution_service/server_implementation.cpp
+++ b/src/buildtool/execution_api/execution_service/server_implementation.cpp
@@ -27,7 +27,7 @@
 
 #include <grpcpp/grpcpp.h>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/auth/authentication.hpp"
 #include "src/buildtool/common/protocol_traits.hpp"

--- a/src/buildtool/execution_api/local/config.hpp
+++ b/src/buildtool/execution_api/local/config.hpp
@@ -21,7 +21,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/utils/cpp/expected.hpp"
 
 /// \brief Store local execution configuration.

--- a/src/buildtool/execution_api/local/local_cas_reader.cpp
+++ b/src/buildtool/execution_api/local/local_cas_reader.cpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/common/protocol_traits.hpp"

--- a/src/buildtool/execution_api/local/local_response.hpp
+++ b/src/buildtool/execution_api/local/local_response.hpp
@@ -25,7 +25,7 @@
 #include <unordered_set>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "gsl/gsl"
 #include "src/buildtool/common/artifact.hpp"

--- a/src/buildtool/execution_api/remote/bazel/bazel_capabilities_client.cpp
+++ b/src/buildtool/execution_api/remote/bazel/bazel_capabilities_client.cpp
@@ -22,7 +22,7 @@
 #include <grpcpp/grpcpp.h>
 
 #include "build/bazel/semver/semver.pb.h"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/bazel_types.hpp"
 #include "src/buildtool/common/remote/client_common.hpp"
 #include "src/buildtool/common/remote/retry.hpp"

--- a/src/buildtool/execution_api/remote/bazel/bazel_cas_client.hpp
+++ b/src/buildtool/execution_api/remote/bazel/bazel_cas_client.hpp
@@ -26,7 +26,7 @@
 #include <grpcpp/support/status.h>
 
 #include "build/bazel/remote/execution/v2/remote_execution.grpc.pb.h"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/buildtool/auth/authentication.hpp"
 #include "src/buildtool/common/artifact_blob.hpp"

--- a/src/buildtool/execution_api/remote/bazel/bazel_execution_client.cpp
+++ b/src/buildtool/execution_api/remote/bazel/bazel_execution_client.cpp
@@ -18,7 +18,7 @@
 
 #include <grpcpp/grpcpp.h>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/any.pb.h"
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/timestamp.pb.h"

--- a/src/buildtool/execution_api/remote/bazel/bazel_response.cpp
+++ b/src/buildtool/execution_api/remote/bazel/bazel_response.cpp
@@ -24,7 +24,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "src/buildtool/common/artifact.hpp"
 #include "src/buildtool/common/artifact_blob.hpp"

--- a/src/buildtool/execution_api/remote/config.cpp
+++ b/src/buildtool/execution_api/remote/config.cpp
@@ -16,7 +16,7 @@
 
 #include <exception>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 

--- a/src/buildtool/execution_api/utils/rehash_utils.cpp
+++ b/src/buildtool/execution_api/utils/rehash_utils.cpp
@@ -22,7 +22,7 @@
 #include <utility>  // std::move
 #include <variant>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/protocol_traits.hpp"
 #include "src/buildtool/crypto/hash_function.hpp"
 #include "src/buildtool/execution_api/bazel_msg/bazel_msg_factory.hpp"

--- a/src/buildtool/execution_engine/executor/executor.hpp
+++ b/src/buildtool/execution_engine/executor/executor.hpp
@@ -33,7 +33,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/expression/evaluator.hpp"

--- a/src/buildtool/execution_engine/tree_operations/tree_operations_utils.cpp
+++ b/src/buildtool/execution_engine/tree_operations/tree_operations_utils.cpp
@@ -24,7 +24,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/artifact_blob.hpp"

--- a/src/buildtool/file_system/atomic.cpp
+++ b/src/buildtool/file_system/atomic.cpp
@@ -25,7 +25,7 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 
 auto FileSystemAtomic::WriteFile(std::string const& filename,
                                  std::string const& content) noexcept -> bool {

--- a/src/buildtool/file_system/file_root.hpp
+++ b/src/buildtool/file_system/file_root.hpp
@@ -28,7 +28,7 @@
 #include <utility>
 #include <variant>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/artifact_description.hpp"

--- a/src/buildtool/file_system/file_system_manager.hpp
+++ b/src/buildtool/file_system/file_system_manager.hpp
@@ -49,7 +49,7 @@
 #include <utility>
 #include <variant>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/file_system/object_type.hpp"

--- a/src/buildtool/file_system/git_repo.cpp
+++ b/src/buildtool/file_system/git_repo.cpp
@@ -27,7 +27,7 @@
 #include <thread>
 #include <unordered_set>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/crypto/hash_function.hpp"
 #include "src/buildtool/file_system/file_system_manager.hpp"

--- a/src/buildtool/file_system/git_utils.cpp
+++ b/src/buildtool/file_system/git_utils.cpp
@@ -14,7 +14,7 @@
 
 #include "src/buildtool/file_system/git_utils.hpp"
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/logger.hpp"
 #include "src/utils/cpp/hex_string.hpp"

--- a/src/buildtool/file_system/precomputed_root.cpp
+++ b/src/buildtool/file_system/precomputed_root.cpp
@@ -17,7 +17,7 @@
 #include <compare>
 #include <exception>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/utils/cpp/hash_combine.hpp"
 

--- a/src/buildtool/file_system/symlinks/resolve_symlinks_map.cpp
+++ b/src/buildtool/file_system/symlinks/resolve_symlinks_map.cpp
@@ -18,7 +18,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/file_system/object_type.hpp"
 #include "src/utils/cpp/gsl.hpp"
 #include "src/utils/cpp/hex_string.hpp"

--- a/src/buildtool/graph_traverser/graph_traverser.cpp
+++ b/src/buildtool/graph_traverser/graph_traverser.cpp
@@ -35,7 +35,7 @@
 #include <thread>
 #include <unordered_set>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact_blob.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/common/statistics.hpp"

--- a/src/buildtool/logging/log_sink_cmdline.hpp
+++ b/src/buildtool/logging/log_sink_cmdline.hpp
@@ -24,8 +24,9 @@
 #include <sstream>
 #include <string>
 
+#include "fmt/base.h"
 #include "fmt/color.h"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/log_sink.hpp"
 #include "src/buildtool/logging/logger.hpp"

--- a/src/buildtool/logging/log_sink_file.hpp
+++ b/src/buildtool/logging/log_sink_file.hpp
@@ -29,8 +29,9 @@
 #include <thread>
 #include <unordered_map>
 
+#include "fmt/base.h"
 #include "fmt/chrono.h"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/log_sink.hpp"

--- a/src/buildtool/logging/logger.hpp
+++ b/src/buildtool/logging/logger.hpp
@@ -22,7 +22,8 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/base.h"
+#include "fmt/format.h"
 #include "src/buildtool/logging/log_config.hpp"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/log_sink.hpp"

--- a/src/buildtool/main/analyse.cpp
+++ b/src/buildtool/main/analyse.cpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/base_maps/directory_map.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name_data.hpp"

--- a/src/buildtool/main/build_utils.cpp
+++ b/src/buildtool/main/build_utils.cpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <unordered_set>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/build_engine/expression/expression.hpp"
 #include "src/buildtool/build_engine/expression/expression_ptr.hpp"
 #ifndef BOOTSTRAP_BUILD_TOOL

--- a/src/buildtool/main/describe.cpp
+++ b/src/buildtool/main/describe.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name.hpp"
 #include "src/buildtool/build_engine/base_maps/module_name.hpp"

--- a/src/buildtool/main/diagnose.cpp
+++ b/src/buildtool/main/diagnose.cpp
@@ -28,7 +28,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/analysed_target/analysed_target.hpp"

--- a/src/buildtool/main/main.cpp
+++ b/src/buildtool/main/main.cpp
@@ -79,7 +79,7 @@
 #include "src/utils/cpp/expected.hpp"
 #include "src/utils/cpp/json.hpp"
 #ifndef BOOTSTRAP_BUILD_TOOL
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/auth/authentication.hpp"
 #include "src/buildtool/common/remote/retry_config.hpp"
 #include "src/buildtool/computed_roots/evaluate.hpp"

--- a/src/buildtool/multithreading/async_map_utils.hpp
+++ b/src/buildtool/multithreading/async_map_utils.hpp
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/logger.hpp"
 #include "src/buildtool/multithreading/async_map_consumer.hpp"

--- a/src/buildtool/progress_reporting/exports_progress_reporter.cpp
+++ b/src/buildtool/progress_reporting/exports_progress_reporter.cpp
@@ -17,7 +17,7 @@
 #include <functional>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/progress_reporting/task_tracker.hpp"
 

--- a/src/buildtool/progress_reporting/progress_reporter.cpp
+++ b/src/buildtool/progress_reporting/progress_reporter.cpp
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name_data.hpp"
 #include "src/buildtool/build_engine/target_map/configured_target.hpp"

--- a/src/buildtool/serve_api/remote/config.hpp
+++ b/src/buildtool/serve_api/remote/config.hpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/remote/remote_common.hpp"
 #include "src/buildtool/main/build_utils.hpp"
 #include "src/utils/cpp/expected.hpp"

--- a/src/buildtool/serve_api/remote/serve_api.cpp
+++ b/src/buildtool/serve_api/remote/serve_api.cpp
@@ -16,7 +16,7 @@
 
 #include "src/buildtool/serve_api/remote/serve_api.hpp"
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact.hpp"
 #include "src/buildtool/common/protocol_traits.hpp"
 #include "src/buildtool/common/repository_config.hpp"

--- a/src/buildtool/serve_api/remote/target_client.cpp
+++ b/src/buildtool/serve_api/remote/target_client.cpp
@@ -22,7 +22,7 @@
 
 #include <grpcpp/grpcpp.h>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "justbuild/just_serve/just_serve.pb.h"
 #include "nlohmann/json.hpp"

--- a/src/buildtool/serve_api/serve_service/serve_server_implementation.cpp
+++ b/src/buildtool/serve_api/serve_service/serve_server_implementation.cpp
@@ -30,7 +30,7 @@
 
 #include <grpcpp/grpcpp.h>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/auth/authentication.hpp"
 #include "src/buildtool/common/protocol_traits.hpp"

--- a/src/buildtool/serve_api/serve_service/source_tree.cpp
+++ b/src/buildtool/serve_api/serve_service/source_tree.cpp
@@ -20,7 +20,7 @@
 #include <functional>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/artifact.hpp"

--- a/src/buildtool/serve_api/serve_service/target.cpp
+++ b/src/buildtool/serve_api/serve_service/target.cpp
@@ -21,7 +21,7 @@
 #include <optional>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/base_maps/entity_name.hpp"

--- a/src/buildtool/serve_api/serve_service/target_utils.cpp
+++ b/src/buildtool/serve_api/serve_service/target_utils.cpp
@@ -21,7 +21,7 @@
 #include <variant>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/file_system/file_root.hpp"
 #include "src/buildtool/file_system/git_cas.hpp"

--- a/src/buildtool/storage/backend_description.cpp
+++ b/src/buildtool/storage/backend_description.cpp
@@ -17,7 +17,7 @@
 #include <exception>
 #include <map>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/file_system/object_type.hpp"

--- a/src/buildtool/storage/compactification_task.hpp
+++ b/src/buildtool/storage/compactification_task.hpp
@@ -19,7 +19,8 @@
 #include <functional>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/base.h"
+#include "fmt/format.h"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/logger.hpp"
 #include "src/buildtool/storage/local_cas.hpp"

--- a/src/buildtool/storage/config.hpp
+++ b/src/buildtool/storage/config.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/buildtool/common/protocol_traits.hpp"
 #include "src/buildtool/crypto/hash_function.hpp"

--- a/src/buildtool/storage/fs_utils.cpp
+++ b/src/buildtool/storage/fs_utils.cpp
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/buildtool/logging/log_level.hpp"

--- a/src/buildtool/storage/garbage_collector.cpp
+++ b/src/buildtool/storage/garbage_collector.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/crypto/hash_function.hpp"
 #include "src/buildtool/execution_api/common/ids.hpp"
 #include "src/buildtool/execution_api/common/message_limits.hpp"

--- a/src/buildtool/storage/large_object_cas.tpp
+++ b/src/buildtool/storage/large_object_cas.tpp
@@ -21,7 +21,7 @@
 #include <cstdlib>
 #include <fstream>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/common/protocol_traits.hpp"

--- a/src/buildtool/storage/local_ac.tpp
+++ b/src/buildtool/storage/local_ac.tpp
@@ -20,7 +20,7 @@
 #include <tuple>    //std::ignore
 #include <utility>  // std::move
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/common/bazel_types.hpp"

--- a/src/buildtool/storage/local_cas.tpp
+++ b/src/buildtool/storage/local_cas.tpp
@@ -20,7 +20,7 @@
 #include <cstddef>
 #include <utility>  // std::move
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/common/bazel_types.hpp"
 #include "src/buildtool/file_system/git_repo.hpp"

--- a/src/buildtool/storage/repository_garbage_collector.cpp
+++ b/src/buildtool/storage/repository_garbage_collector.cpp
@@ -17,7 +17,7 @@
 #include <cstddef>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/execution_api/common/ids.hpp"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/buildtool/logging/log_level.hpp"

--- a/src/buildtool/tree_structure/tree_structure_utils.cpp
+++ b/src/buildtool/tree_structure/tree_structure_utils.cpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/common/protocol_traits.hpp"

--- a/src/other_tools/git_operations/git_config_settings.cpp
+++ b/src/other_tools/git_operations/git_config_settings.cpp
@@ -19,7 +19,7 @@
 #include <map>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/other_tools/utils/curl_url_handle.hpp"
 

--- a/src/other_tools/git_operations/git_operations.cpp
+++ b/src/other_tools/git_operations/git_operations.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/other_tools/git_operations/git_repo_remote.hpp"
 

--- a/src/other_tools/git_operations/git_repo_remote.cpp
+++ b/src/other_tools/git_operations/git_repo_remote.cpp
@@ -22,7 +22,7 @@
 #include <map>
 #include <utility>  // std::move
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/file_system/file_system_manager.hpp"

--- a/src/other_tools/just_mr/cli.hpp
+++ b/src/other_tools/just_mr/cli.hpp
@@ -29,7 +29,7 @@
 #include <vector>
 
 #include "CLI/CLI.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/clidefaults.hpp"

--- a/src/other_tools/just_mr/fetch.cpp
+++ b/src/other_tools/just_mr/fetch.cpp
@@ -26,7 +26,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/expression/expression.hpp"

--- a/src/other_tools/just_mr/launch.cpp
+++ b/src/other_tools/just_mr/launch.cpp
@@ -37,7 +37,7 @@
 #include <vector>
 
 #include "fmt/chrono.h"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/expression/configuration.hpp"
 #include "src/buildtool/build_engine/expression/expression.hpp"

--- a/src/other_tools/just_mr/progress_reporting/progress_reporter.cpp
+++ b/src/other_tools/just_mr/progress_reporting/progress_reporter.cpp
@@ -17,7 +17,7 @@
 #include <functional>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/logger.hpp"

--- a/src/other_tools/just_mr/update.cpp
+++ b/src/other_tools/just_mr/update.cpp
@@ -27,7 +27,7 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/expression/expression.hpp"
 #include "src/buildtool/build_engine/expression/expression_ptr.hpp"

--- a/src/other_tools/ops_maps/archive_fetch_map.cpp
+++ b/src/other_tools/ops_maps/archive_fetch_map.cpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/file_system/file_system_manager.hpp"

--- a/src/other_tools/ops_maps/content_cas_map.cpp
+++ b/src/other_tools/ops_maps/content_cas_map.cpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <utility>  // std::move
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/crypto/hasher.hpp"

--- a/src/other_tools/ops_maps/git_tree_fetch_map.cpp
+++ b/src/other_tools/ops_maps/git_tree_fetch_map.cpp
@@ -21,7 +21,7 @@
 #include <optional>
 #include <utility>  // std::move
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/common/artifact.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"

--- a/src/other_tools/ops_maps/git_update_map.cpp
+++ b/src/other_tools/ops_maps/git_update_map.cpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <optional>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/progress_reporting/task_tracker.hpp"
 #include "src/other_tools/git_operations/git_repo_remote.hpp"
 

--- a/src/other_tools/ops_maps/import_to_git_map.cpp
+++ b/src/other_tools/ops_maps/import_to_git_map.cpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <optional>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/multithreading/task_system.hpp"
 #include "src/other_tools/git_operations/git_ops_types.hpp"
 #include "src/other_tools/git_operations/git_repo_remote.hpp"

--- a/src/other_tools/repo_map/repos_to_setup_map.cpp
+++ b/src/other_tools/repo_map/repos_to_setup_map.cpp
@@ -20,7 +20,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/build_engine/expression/expression.hpp"
 #include "src/buildtool/build_engine/expression/expression_ptr.hpp"
 #include "src/buildtool/crypto/hash_function.hpp"

--- a/src/other_tools/root_maps/commit_git_map.cpp
+++ b/src/other_tools/root_maps/commit_git_map.cpp
@@ -19,7 +19,7 @@
 #include <optional>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"

--- a/src/other_tools/root_maps/content_git_map.cpp
+++ b/src/other_tools/root_maps/content_git_map.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/crypto/hash_function.hpp"

--- a/src/other_tools/root_maps/distdir_git_map.cpp
+++ b/src/other_tools/root_maps/distdir_git_map.cpp
@@ -18,7 +18,7 @@
 #include <filesystem>
 #include <optional>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"

--- a/src/other_tools/root_maps/foreign_file_git_map.cpp
+++ b/src/other_tools/root_maps/foreign_file_git_map.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/crypto/hash_info.hpp"
 #include "src/buildtool/file_system/file_root.hpp"

--- a/src/other_tools/root_maps/fpath_git_map.cpp
+++ b/src/other_tools/root_maps/fpath_git_map.cpp
@@ -18,7 +18,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact_digest_factory.hpp"
 #include "src/buildtool/crypto/hash_function.hpp"
 #include "src/buildtool/file_system/file_root.hpp"

--- a/src/other_tools/root_maps/tree_id_git_map.cpp
+++ b/src/other_tools/root_maps/tree_id_git_map.cpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/file_system/file_root.hpp"

--- a/src/other_tools/utils/content.hpp
+++ b/src/other_tools/utils/content.hpp
@@ -21,7 +21,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/user_structs.hpp"
 #include "src/buildtool/crypto/hasher.hpp"
 #include "src/buildtool/logging/log_level.hpp"

--- a/src/other_tools/utils/curl_easy_handle.cpp
+++ b/src/other_tools/utils/curl_easy_handle.cpp
@@ -18,7 +18,7 @@
 #include <exception>
 #include <fstream>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/logger.hpp"

--- a/src/other_tools/utils/parse_archive.cpp
+++ b/src/other_tools/utils/parse_archive.cpp
@@ -21,7 +21,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/build_engine/expression/expression.hpp"
 #include "src/buildtool/crypto/hash_function.hpp"
 #include "src/buildtool/crypto/hash_info.hpp"

--- a/src/other_tools/utils/parse_git_tree.cpp
+++ b/src/other_tools/utils/parse_git_tree.cpp
@@ -19,7 +19,7 @@
 #include <utility>  // std::move
 #include <vector>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/expression/expression.hpp"
 #include "src/buildtool/crypto/hash_function.hpp"

--- a/src/other_tools/utils/parse_precomputed_root.cpp
+++ b/src/other_tools/utils/parse_precomputed_root.cpp
@@ -16,7 +16,7 @@
 
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "nlohmann/json.hpp"
 #include "src/buildtool/build_engine/expression/expression.hpp"
 

--- a/src/utils/cpp/incremental_reader.cpp
+++ b/src/utils/cpp/incremental_reader.cpp
@@ -18,7 +18,7 @@
 #include <exception>
 #include <string_view>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/utils/cpp/in_place_visitor.hpp"
 
 namespace {

--- a/src/utils/cpp/json.hpp
+++ b/src/utils/cpp/json.hpp
@@ -26,7 +26,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include "fmt/core.h"
+#include "fmt/base.h"
 #include "fmt/ostream.h"
 #include "nlohmann/json.hpp"
 #include "src/utils/cpp/gsl.hpp"

--- a/test/buildtool/build_engine/base_maps/test_repo.hpp
+++ b/test/buildtool/build_engine/base_maps/test_repo.hpp
@@ -21,7 +21,7 @@
 #include <optional>
 #include <string>
 
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "test/utils/shell_quoting.hpp"
 

--- a/test/buildtool/execution_api/common/api_test.hpp
+++ b/test/buildtool/execution_api/common/api_test.hpp
@@ -31,7 +31,7 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/catch_tostring.hpp"
 #include "catch2/generators/catch_generators_all.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/buildtool/common/artifact.hpp"
 #include "src/buildtool/common/artifact_blob.hpp"

--- a/test/buildtool/execution_api/execution_service/execution_server.test.cpp
+++ b/test/buildtool/execution_api/execution_service/execution_server.test.cpp
@@ -36,7 +36,7 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/catch_tostring.hpp"
 #include "catch2/generators/catch_generators_all.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "gsl/gsl"
 #include "src/buildtool/common/artifact_digest.hpp"

--- a/test/buildtool/execution_api/local/local_execution.test.cpp
+++ b/test/buildtool/execution_api/local/local_execution.test.cpp
@@ -25,7 +25,7 @@
 #include <vector>
 
 #include "catch2/catch_test_macros.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/buildtool/common/artifact_blob.hpp"
 #include "src/buildtool/common/artifact_description.hpp"

--- a/test/buildtool/file_system/directory_entries.test.cpp
+++ b/test/buildtool/file_system/directory_entries.test.cpp
@@ -21,7 +21,7 @@
 #include <unordered_set>
 
 #include "catch2/catch_test_macros.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/file_system/file_root.hpp"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "test/utils/shell_quoting.hpp"

--- a/test/buildtool/file_system/file_root.test.cpp
+++ b/test/buildtool/file_system/file_root.test.cpp
@@ -22,7 +22,7 @@
 #include <string_view>
 
 #include "catch2/catch_test_macros.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/artifact_description.hpp"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/common/artifact_digest_factory.hpp"

--- a/test/buildtool/file_system/file_system_manager.test.cpp
+++ b/test/buildtool/file_system/file_system_manager.test.cpp
@@ -30,7 +30,7 @@
 
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators_all.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/file_system/object_type.hpp"
 #include "src/buildtool/logging/log_level.hpp"
 #include "src/buildtool/logging/logger.hpp"

--- a/test/buildtool/file_system/git_repo.test.cpp
+++ b/test/buildtool/file_system/git_repo.test.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "catch2/catch_test_macros.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/buildtool/file_system/git_cas.hpp"
 #include "src/buildtool/file_system/object_type.hpp"

--- a/test/buildtool/file_system/git_tree.test.cpp
+++ b/test/buildtool/file_system/git_tree.test.cpp
@@ -29,7 +29,7 @@
 
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_all.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "gsl/gsl"
 #include "src/buildtool/common/artifact_digest.hpp"
 #include "src/buildtool/file_system/file_system_manager.hpp"

--- a/test/buildtool/file_system/resolve_symlinks_map.test.cpp
+++ b/test/buildtool/file_system/resolve_symlinks_map.test.cpp
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "catch2/catch_test_macros.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/buildtool/file_system/git_cas.hpp"
 #include "src/buildtool/file_system/object_type.hpp"

--- a/test/other_tools/git_operations/critical_git_ops.test.cpp
+++ b/test/other_tools/git_operations/critical_git_ops.test.cpp
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "catch2/catch_test_macros.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/execution_api/common/ids.hpp"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/buildtool/multithreading/task_system.hpp"

--- a/test/other_tools/git_operations/git_repo_remote.test.cpp
+++ b/test/other_tools/git_operations/git_repo_remote.test.cpp
@@ -25,7 +25,7 @@
 #include <vector>
 
 #include "catch2/catch_test_macros.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/file_system/file_system_manager.hpp"
 #include "src/buildtool/file_system/git_cas.hpp"
 #include "src/buildtool/logging/log_level.hpp"

--- a/test/utils/serve_service/main-serve.cpp
+++ b/test/utils/serve_service/main-serve.cpp
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "catch2/catch_session.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "src/buildtool/common/remote/remote_common.hpp"
 #include "src/buildtool/file_system/git_context.hpp"
 #include "src/buildtool/logging/log_level.hpp"


### PR DESCRIPTION
... including the necessary changes of include statements.In this way, we unlock packaging in distros that have already updated to the latest version of fmtlib.